### PR TITLE
bandit_sim.R renderTable align argument fix

### DIFF
--- a/R/bandit_sim.R
+++ b/R/bandit_sim.R
@@ -153,10 +153,10 @@ bandit_sim = function()
                                "machine = c(",m,"), ",
                                "outcome = c(",o,"))")
                       })
-        output$tab = renderTable(values$tab, align="lccc")
+        output$tab = renderTable(values$tab, align="ccc")
         output$res = renderTable(values$res,
                                  include.rownames=FALSE,
-                                 align="cccc")
+                                 align="ccc")
     }
   )
 }


### PR DESCRIPTION
fixes table rendering error 

error message:
Warning: Error in origRenderFunc: `align` must contain only the characters `l`, `c`, `r` and/or `?` andhave length either equal to 1 or to the total number of columns
Stack trace (innermost first):
    79: origRenderFunc
    78: output$tab
     3: <Anonymous>
     2: do.call
     1: rmarkdown::run

related to https://www.coursera.org/learn/bayesian/discussions/weeks/1/threads/mTrbMHd8EeaX3g4cIbI3IQ
